### PR TITLE
dev/logging

### DIFF
--- a/lib/bot/__init__.py
+++ b/lib/bot/__init__.py
@@ -76,6 +76,8 @@ class MOCBOT(commands.Bot):
             f"Connected on {self.user.name} ({self.mode}) | d.py v{str(discord.__version__)}"
         )
 
+    async def on_interaction(self, interaction):
+        logger.info(f"[COMMAND] [{interaction.guild} // {interaction.guild.id}] {interaction.user} ({interaction.user.id}) used command {interaction.command.name}")
 
     async def on_message(self, message):
         await self.wait_until_ready()

--- a/lib/cogs/Cogs.py
+++ b/lib/cogs/Cogs.py
@@ -7,6 +7,7 @@ import discord
 
 from glob import glob
 import os
+import traceback
 
 
 class Cogs(commands.Cog):
@@ -27,6 +28,7 @@ class Cogs(commands.Cog):
             await self.bot.load_extension(f"lib.cogs.{cog}")
         except Exception as e:
             logger.error(f"[COG] {cog} failed to load. {e}")
+            traceback.print_exc()
 
     async def load_cogs(self):
         if not self.unloaded_cogs:

--- a/lib/cogs/ErrorHandler.py
+++ b/lib/cogs/ErrorHandler.py
@@ -1,4 +1,5 @@
 from discord.ext import commands
+from discord.app_commands import errors
 from discord.ui import Button, View
 from discord import app_commands
 from lib.bot import config, logger, MOCBOT, DEV_GUILD, MOC_DB
@@ -20,8 +21,11 @@ class ErrorHandler(commands.Cog):
         logger.info(f"[COG] Loaded {self.__class__.__name__}")
         
     async def on_app_command_error(self, interaction, error):
-        await interaction.response.send_message(embed=self.bot.create_embed("MOCBOT ERROR", error, 0xFF0000), ephemeral=True)
-        logger.error(f"[ERROR] Interaction Error: {error}")
+        embed = self.bot.create_embed("MOCBOT ERROR", "An unexpected error has occurred.", 0xFF0000)
+        embed.add_field(name="ERROR:", value="> {}\n\nIf this error is a regular occurrence, please contact the team with `/contact`. This error has been logged.".format(str(error)), inline=False)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+        
+        logger.error(f"[ERROR] Unhandled Error: {error}")
         traceback.print_exc()
 
 


### PR DESCRIPTION
Commands invocation is now logged. Cog load failure now calls a traceback and error handling now displays a nice error message, resolving the "application did not respond" message.