### PR TITLE
Added join role support

### DIFF
--- a/lib/cogs/Roles.py
+++ b/lib/cogs/Roles.py
@@ -1,0 +1,40 @@
+from discord.ext import commands
+import logging
+from discord import Member, Object
+
+from utils.APIHandler import API
+from requests.exceptions import HTTPError
+
+class Roles(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.logger = logging.getLogger(__name__)
+
+    async def cog_load(self):
+        self.logger.info(f"[COG] Loaded {self.__class__.__name__}")
+
+    @staticmethod
+    async def give_join_roles(member: Member):
+        try:
+            rolesData = API.get(f'/roles/{member.guild.id}')
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                return
+            else:
+                raise e 
+        if rolesData and rolesData.get("JoinRoles"):
+            for roleID in rolesData.get("JoinRoles"):
+                await member.add_roles(Object(id=int(roleID)), reason="Join Role")
+
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: Member):
+        settingsData = API.get(f'/settings/{member.guild.id}')
+        if "Verification" not in settingsData.get("EnabledModules"):
+            await Roles.give_join_roles(member)
+      
+
+
+async def setup(bot):
+    await bot.add_cog(Roles(bot))

--- a/lib/cogs/Roles.py
+++ b/lib/cogs/Roles.py
@@ -1,6 +1,7 @@
+import traceback
 from discord.ext import commands
 import logging
-from discord import Member, Object
+from discord import Member, Object, HTTPException
 
 from utils.APIHandler import API
 from requests.exceptions import HTTPError
@@ -25,8 +26,10 @@ class Roles(commands.Cog):
                 raise e 
         if rolesData and rolesData.get("JoinRoles"):
             for roleID in rolesData.get("JoinRoles"):
-                await member.add_roles(Object(id=int(roleID)), reason="Join Role")
-
+                try:
+                    await member.add_roles(Object(id=int(roleID)), reason="Join Role")
+                except HTTPException as e:
+                    continue
 
     @commands.Cog.listener()
     async def on_member_join(self, member: Member):

--- a/lib/cogs/Verification.py
+++ b/lib/cogs/Verification.py
@@ -13,6 +13,8 @@ import discord
 import datetime
 import time
 
+from lib.cogs.Roles import Roles
+
 class VerificationStatus(Enum):
     SUCCESS = 1,
     LOCKDOWN = 2,
@@ -41,6 +43,7 @@ class Verification(commands.Cog):
         match await Verification.verify_user(member, settings.get("Verification"), admin=admin, **kwargs):
             case VerificationStatus.SUCCESS:
                 await Socket.emit("verify_success", namespace="/verification")
+                await Roles.give_join_roles(member)
             case VerificationStatus.LOCKDOWN:
                 await Socket.emit("verify_lockdown", namespace="/verification")
             case VerificationStatus.ERROR:


### PR DESCRIPTION
Given valid join roles, the bot will assign new users who join a MOCBOT guild with specified join roles,
- Immediately, if the verification system is not enabled, or
- Upon successful verification, if the verifcation system is enabled.