### PR TITLE
Changed verification prompt link to prod

### DIFF
--- a/lib/cogs/Verification.py
+++ b/lib/cogs/Verification.py
@@ -166,7 +166,7 @@ class Verification(commands.Cog):
         await member.add_roles(Object(id=settings.get("VerificationRoleID")))
         API.post(f'/verification/{member.guild.id}/{member.id}', {})
         try:
-            await member.send(embed=self.bot.create_embed("MOCBOT VERIFICATION", f"**Welcome to {member.guild}!**\n\n To get verified, please click [here](http://localhost:3000/verify/{member.guild.id}/{member.id}).", None))
+            await member.send(embed=self.bot.create_embed("MOCBOT VERIFICATION", f"**Welcome to {member.guild}!**\n\n To get verified, please click [here](https://mocbot.masterofcubesau.com/verify/{member.guild.id}/{member.id}).", None))
         except Forbidden:
             pass 
 


### PR DESCRIPTION
Link which is prompted to get users to verify themselves now shows the correct prod link `https://mocbot.masterofcubesau.com/verify/[guild_id]/[user_id]`