### PR TITLE
Fixed web_verify_kick

### DIFF
--- a/lib/cogs/Verification.py
+++ b/lib/cogs/Verification.py
@@ -66,12 +66,13 @@ class Verification(commands.Cog):
             else:
                 raise e
         else:
-            try:
-                channel = await member.guild.fetch_channel(int(data.get("ChannelID")))
-                message = await channel.fetch_message(int(data.get("MessageID")))
-                await message.delete()
-            except (HTTPException, Forbidden):
-                pass
+            if data.get("ChannelID") and data.get("MessageID"):
+                try:
+                    channel = await member.guild.fetch_channel(int(data.get("ChannelID")))
+                    message = await channel.fetch_message(int(data.get("MessageID")))
+                    await message.delete()
+                except (HTTPException, Forbidden):
+                    pass
         API.delete(f'/verification/{member.guild.id}/{member.id}')
         try:
             await member.send(embed=Verification.bot.create_embed("MOCBOT VERIFICATION", f"You have been denied access in **{member.guild}**{' by {}'.format(admin.mention)}.", None))


### PR DESCRIPTION
This PR fixes a bug where when kicking a user through the dashboard where the user was not in lockdown (pending verification), the bot would ignore the request. 