### PR TITLE
📦️ Update Lavalink library version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 discord-ext-menus==1.1.0
 discord.py==2.3.2
 expiringdict==1.2.2
-lavalink==5.3.0
+lavalink==5.7.1
 Pillow==9.3.0
 python-socketio==5.11.0
 PyYAML==6.0.1


### PR DESCRIPTION
Updates Lavalink library version to 5.7.1 to maintain comptability with newer versions of the Lavalink client.